### PR TITLE
Added technexion patches for WDOG_B pin and user key reset

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8mp-edm-g-wb.dts
+++ b/arch/arm64/boot/dts/freescale/imx8mp-edm-g-wb.dts
@@ -134,7 +134,7 @@
 	};
 
 };
-/*
+
 &gpio1 {
 	pinctrl-0 = <&pinctrl_gpio1>;
 	gpio-line-names =	\
@@ -142,8 +142,15 @@
 		"", "", "", "", "", "", "", "",	\
 		"", "", "", "", "", "", "", "",	\
 		"", "", "", "", "", "", "", "";
+
+	CPU_INT {
+		gpio-hog;
+		gpios = <10 0>;
+		output-high;
+	};
 };
 
+/*
 &gpio4 {
 	pinctrl-0 = <&pinctrl_gpio4>;
 	gpio-line-names =	\

--- a/arch/arm64/boot/dts/freescale/imx8mp-edm-g.dtsi
+++ b/arch/arm64/boot/dts/freescale/imx8mp-edm-g.dtsi
@@ -883,7 +883,7 @@
 
 	pinctrl_wdog: wdoggrp {
 		fsl,pins = <
-			MX8MP_IOMUXC_GPIO1_IO02__WDOG1_WDOG_B	0xc6
+			MX8MP_IOMUXC_GPIO1_IO02__WDOG1_WDOG_B	0x26
 		>;
 	};
 


### PR DESCRIPTION

Title: WDOG_B pin was set as output from SOM side
Solution: Technexion provided patches which are added in below PR
ticket: https://trackonomy.atlassian.net/browse/FW-3053
testing: TBD