### PR TITLE
Disabled RTC interrupt in device tree

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8mp-edm-g-wb.dts
+++ b/arch/arm64/boot/dts/freescale/imx8mp-edm-g-wb.dts
@@ -404,9 +404,9 @@
 		compatible = "nxp,pca21125";
 		pinctrl-names = "default";
 		pinctrl-0 = <&pinctrl_rtc>;
-		interrupt-parent = <&gpio4>;
+		/* interrupt-parent = <&gpio4>;
 		interrupts = <1 IRQ_TYPE_EDGE_FALLING>;
-		int-gpio = <&gpio4 1 GPIO_ACTIVE_LOW>;
+		int-gpio = <&gpio4 1 GPIO_ACTIVE_LOW>;*/
 		spi-max-frequency = <1500000>;
 		spi-cs-high;
 		reg = <0>;


### PR DESCRIPTION
Title: Disabled RTC interrupt in device tree
description: For board 2.4 we are getting crash for RTC int pin, since currently only solution is to disable it
ticket: https://trackonomy.atlassian.net/browse/FW-3297